### PR TITLE
Model_id for prediction

### DIFF
--- a/notebooks/02-1-train-and-test-sherlock.ipynb
+++ b/notebooks/02-1-train-and-test-sherlock.ipynb
@@ -394,7 +394,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "predicted_labels = model.predict(X_test)\n",
+    "predicted_labels = model.predict(X_test, model_id=model_id)\n",
     "predicted_labels = np.array([x.lower() for x in predicted_labels])"
    ]
   },


### PR DESCRIPTION
Change the prediction of labels from defaul_model('sherlock') to model_id (which was defined prior)